### PR TITLE
Use http over dart:io for web compatibility

### DIFF
--- a/lib/services/http.dart
+++ b/lib/services/http.dart
@@ -1,7 +1,9 @@
-import 'dart:io';
+import 'package:http/http.dart' as http;
 
 class HttpService {
-  final HttpClient client;
+  HttpService();
 
-  HttpService({required this.client});
+  Future<http.Response> get(Uri url) async {
+    return http.get(url);
+  }
 }

--- a/lib/services/wallet_proxy/service.dart
+++ b/lib/services/wallet_proxy/service.dart
@@ -1,10 +1,9 @@
 import 'dart:convert';
-import 'dart:io';
-
+import 'package:concordium_wallet/services/http.dart';
 import 'package:concordium_wallet/services/wallet_proxy/model.dart';
 
 enum WalletProxyEndpoint {
-  tacVersion('/v0/termsAndConditionsVersion'),
+  tacVersion('v0/termsAndConditionsVersion'),
   ;
 
   final String path;
@@ -26,15 +25,15 @@ class WalletProxyConfig {
 
 class WalletProxyService {
   final WalletProxyConfig config;
-  final HttpClient client;
+  final HttpService httpService;
 
-  WalletProxyService({required this.config, required this.client});
+  WalletProxyService({required this.config, required this.httpService});
 
+  /// Retrieves the terms and conditions from the wallet-proxy.
   Future<TermsAndConditions> getTac() async {
     final url = config.urlOf(WalletProxyEndpoint.tacVersion);
-    final req = await client.getUrl(url);
-    final res = await req.close();
-    final str = await res.transform(utf8.decoder).join();
-    return TermsAndConditions.fromJson(json.decode(str));
+    final response = await httpService.get(url);
+    final jsonResponse = jsonDecode(response.body);
+    return TermsAndConditions.fromJson(jsonResponse);
   }
 }

--- a/lib/state.dart
+++ b/lib/state.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import 'package:concordium_wallet/services/http.dart';
 import 'package:concordium_wallet/services/wallet_proxy/service.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -34,7 +33,7 @@ class AppState extends ChangeNotifier {
   final network = testnet;
   final walletProxyService = WalletProxyService(
     config: testnet.walletProxyConfig,
-    client: HttpClient(),
+    httpService: HttpService(),
   );
 
   var _termsAndConditionsLastVerifiedAt = DateTime.fromMicrosecondsSinceEpoch(0); // force recheck when starting app

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -264,6 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   http_multi_server:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   flutter_svg: ^2.0.7
   url_launcher: ^6.1.14
   shared_preferences: ^2.2.1
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Purpose
Make the application run on web as well.

## Changes
- Removed any usage of `dart:io` as it is not supported on web.
- Introduced the `http` dependency to replace it (https://pub.dev/packages/http).

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.