### PR TITLE
Create Apache 2 LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright [2023] [Concordium AG]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Changes

Ensured filename is LICENSE in all caps to be consistent with our other wallet repos, but also to follow the GitHub convention of license file naming.

Chose the Apache-2.0 license, to make our code free of use, but keep logos and names trademarked, again to be consistent with our other open source projects. 

Added the Apache-2.0 license content from the github template, and verified it's an exact copy of the original source: https://www.apache.org/licenses/LICENSE-2.0.txt




