### PR TITLE
[experiment] State management: Migrate to Riverpod

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -26,3 +26,8 @@ linter:
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
+
+# To enable 'riverpod_lint'.
+analyzer:
+  plugins:
+    - custom_lint

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,0 +1,12 @@
+import 'package:concordium_wallet/services/wallet_proxy/service.dart';
+import 'package:concordium_wallet/state/config.dart';
+import 'package:concordium_wallet/state/network.dart';
+
+final config = Config.ofNetworks([
+  const Network(
+    name: NetworkName.testnet,
+    walletProxyConfig: WalletProxyConfig(
+      baseUrl: 'https://wallet-proxy.testnet.concordium.com',
+    ),
+  ),
+]);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,82 +1,29 @@
+import 'package:concordium_wallet/config.dart';
 import 'package:concordium_wallet/screens/routes.dart';
 import 'package:concordium_wallet/services/http.dart';
-import 'package:concordium_wallet/services/shared_preferences/service.dart';
-import 'package:concordium_wallet/services/wallet_proxy/service.dart';
-import 'package:concordium_wallet/state/config.dart';
 import 'package:concordium_wallet/state/network.dart';
 import 'package:concordium_wallet/state/services.dart';
-import 'package:concordium_wallet/state/terms_and_conditions.dart';
 import 'package:concordium_wallet/theme.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-void main() {
-  runApp(const App());
-}
-
-final config = Config.ofNetworks([
-  const Network(
-    name: NetworkName.testnet,
-    walletProxyConfig: WalletProxyConfig(
-      baseUrl: 'https://wallet-proxy.testnet.concordium.com',
-    ),
-  ),
-]);
 const httpService = HttpService();
 
-class App extends StatelessWidget {
-  const App({super.key});
+// From 'https://codewithandrea.com/articles/flutter-state-management-riverpod/#dependency-overrides-with-riverpod'.
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
 
-  @override
-  Widget build(BuildContext context) {
-    return FutureBuilder<SharedPreferences>(
-      future: SharedPreferences.getInstance(),
-      builder: (context, snapshot) {
-        final prefs = snapshot.data;
-        if (prefs == null) {
-          // Loading preferences.
-          return const Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              CircularProgressIndicator(),
-              SizedBox(height: 16),
-              // Setting text direction is required because we're outside 'MaterialApp' widget.
-              Text('Loading shared preferences...', textDirection: TextDirection.ltr),
-            ],
-          );
-        }
-        // Initialize services and provide them to the nested components
-        // (including the state components created in the child provider).
-        return Provider(
-          create: (context) {
-            final testnet = config.availableNetworks[NetworkName.testnet]!;
-            final prefsSvc = SharedPreferencesService(prefs);
-            return ServiceRepository(
-              networkServices: {testnet: NetworkServices.forNetwork(testnet, httpService: httpService)},
-              sharedPreferences: prefsSvc,
-            );
-          },
-          child: MultiProvider(
-            providers: [
-              ChangeNotifierProvider(
-                create: (context) => ActiveNetwork(config.availableNetworks[NetworkName.testnet]!),
-              ),
-              ChangeNotifierProvider(
-                create: (context) {
-                  final prefs = context.read<ServiceRepository>().sharedPreferences;
-                  return TermsAndConditionAcceptance(prefs);
-                },
-              ),
-            ],
-            child: MaterialApp(
-              routes: appRoutes,
-              theme: concordiumTheme(),
-            ),
-          ),
-        );
-      },
-    );
-  }
+  final testnet = config.availableNetworks[NetworkName.testnet]!;
+  final svcs = await initServiceRepository(testnet, httpService);
+  runApp(ProviderScope(
+    overrides: [
+      // Override placeholder provider with the initialized value.
+      // This prevents the provider from having to be async.
+      serviceRepositoryProvider.overrideWithValue(svcs),
+    ],
+    child: MaterialApp(
+      routes: appRoutes,
+      theme: concordiumTheme(),
+    ),
+  ));
 }

--- a/lib/screens/home/screen.dart
+++ b/lib/screens/home/screen.dart
@@ -1,101 +1,93 @@
+import 'package:concordium_wallet/config.dart';
 import 'package:concordium_wallet/screens/terms_and_conditions/screen.dart';
-import 'package:concordium_wallet/services/wallet_proxy/service.dart';
 import 'package:concordium_wallet/state/network.dart';
-import 'package:concordium_wallet/state/services.dart';
 import 'package:concordium_wallet/state/terms_and_conditions.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class HomeScreen extends StatefulWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
 
   @override
-  State<HomeScreen> createState() => _HomeScreenState();
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen> {
+class _HomeScreenState extends ConsumerState<HomeScreen> {
   @override
   void initState() {
     super.initState();
-
-    // Fetch currently valid T&C version unconditionally when initializing the widget.
-    final tacAcceptance = context.read<TermsAndConditionAcceptance>();
-    final network = context.read<ActiveNetwork>();
-    final services = context.read<ServiceRepository>().networkServices[network.active]!;
-    _updateValidTac(services.walletProxy, tacAcceptance);
-  }
-
-  static Future<void> _updateValidTac(WalletProxyService walletProxy, TermsAndConditionAcceptance tacAcceptance) async {
-    final tac = await walletProxy.fetchTermsAndConditions();
-    tacAcceptance.validVersionUpdated(ValidTermsAndConditions.refreshedNow(termsAndConditions: tac));
+    // Initialize "active network" provider.
+    final activeNetwork = ref.read(activeNetworkNotifierProvider.notifier);
+    Future.microtask(() => activeNetwork.select(config.availableNetworks[NetworkName.testnet]!));
   }
 
   @override
   Widget build(BuildContext context) {
+    final validTac = ref.watch(validTermsAndConditionsProvider);
+
     return Scaffold(
       body: Container(
         padding: const EdgeInsets.fromLTRB(16, 64, 16, 16),
         child: Builder(
           builder: (context) {
-            final tacState = context.watch<TermsAndConditionAcceptance>();
-            final validTac = tacState.valid;
-            if (validTac == null) {
-              // Show spinner if no valid T&C have been resolved yet (not as a result of actually ongoing fetch).
-              // Should store the future from '_updateValidTac' and use that in a wrapping 'FutureBuilder'..?
-              return const Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  CircularProgressIndicator(),
-                  SizedBox(height: 16),
-                  Center(child: Text('Waiting for enforced Terms & Conditions...')),
-                ],
-              );
-            }
-            final acceptedTac = tacState.accepted;
-            if (acceptedTac == null || !acceptedTac.isValid(validTac.termsAndConditions)) {
-              return TermsAndConditionsScreen(
-                validTermsAndConditions: validTac.termsAndConditions,
-                acceptedTermsAndConditionsVersion: acceptedTac?.version,
-              );
-            }
-            return Column(
-              children: [
-                Expanded(
-                  child: Column(
-                    children: [
-                      Text('Accepted T&C version: ${tacState.accepted?.version}'),
-                      Text('Valid T&C last refreshed at ${tacState.valid?.refreshedAt}.'),
-                    ],
-                  ),
-                ),
-                ElevatedButton(
-                  onPressed: () => context.read<TermsAndConditionAcceptance>().testResetValidTime(),
-                  child: const Text('Reset update time of valid T&C'),
-                ),
-                const SizedBox(height: 8),
-                ElevatedButton(
-                  onPressed: () => context.read<TermsAndConditionAcceptance>().resetValid(),
-                  // NOTE: This breaks the app because no re-fetch is triggered - hot restart is necessary to recover.
-                  child: const Text('Reset valid T&C (and break the app)'),
-                ),
-                const SizedBox(height: 8),
-                ElevatedButton(
-                  onPressed: () {
-                    const tac = AcceptedTermsAndConditions(version: '1.2.3');
-                    context.read<TermsAndConditionAcceptance>().userAccepted(tac);
-                  },
-                  child: const Text('Set accepted T&C version to 1.2.3'),
-                ),
-                const SizedBox(height: 8),
-                ElevatedButton(
-                  onPressed: () => context.read<TermsAndConditionAcceptance>().resetAccepted(),
-                  child: const Text('Reset accepted T&C'),
-                ),
-              ],
-            );
+            return switch (validTac) {
+              AsyncData(:final value) => value == null ? const Text('Nothing to display') : _renderHome(ref, value),
+              AsyncError() => const Text('Oops, something unexpected happened'),
+              _ => _renderSpinner(),
+            };
           },
         ),
       ),
     );
   }
+}
+
+Widget _renderSpinner() {
+  return const Column(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      CircularProgressIndicator(),
+      SizedBox(height: 16),
+      Center(child: Text('Waiting for enforced Terms & Conditions...')),
+    ],
+  );
+}
+
+Widget _renderHome(WidgetRef ref, ValidTermsAndConditions validTac) {
+  final acceptedTac = ref.watch(termsAndConditionsAcceptedVersionNotifierProvider);
+  if (acceptedTac == null || !acceptedTac.isValid(validTac.termsAndConditions)) {
+    return TermsAndConditionsScreen(
+      validTermsAndConditions: validTac.termsAndConditions,
+      acceptedTermsAndConditionsVersion: acceptedTac?.version,
+    );
+  }
+  return Column(
+    children: [
+      Expanded(
+        child: Column(
+          children: [
+            Text('Accepted T&C version: ${acceptedTac.version}'),
+            Text('Valid T&C last refreshed at ${validTac.refreshedAt}.'),
+          ],
+        ),
+      ),
+      ElevatedButton(
+        onPressed: () => ref.invalidate(validTermsAndConditionsProvider),
+        child: const Text('Reset valid T&C'),
+      ),
+      const SizedBox(height: 8),
+      ElevatedButton(
+        onPressed: () {
+          const tac = AcceptedTermsAndConditions(version: '1.2.3');
+          ref.read(termsAndConditionsAcceptedVersionNotifierProvider.notifier).userAccepted(tac);
+        },
+        child: const Text('Set accepted T&C version to 1.2.3'),
+      ),
+      const SizedBox(height: 8),
+      ElevatedButton(
+        onPressed: () => ref.read(termsAndConditionsAcceptedVersionNotifierProvider.notifier).resetAccepted(),
+        child: const Text('Reset accepted T&C'),
+      ),
+    ],
+  );
 }

--- a/lib/screens/terms_and_conditions/screen.dart
+++ b/lib/screens/terms_and_conditions/screen.dart
@@ -2,21 +2,21 @@ import 'package:concordium_wallet/screens/terms_and_conditions/widget.dart';
 import 'package:concordium_wallet/services/wallet_proxy/model.dart';
 import 'package:concordium_wallet/state/terms_and_conditions.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class TermsAndConditionsScreen extends StatefulWidget {
+class TermsAndConditionsScreen extends ConsumerStatefulWidget {
   final TermsAndConditions validTermsAndConditions;
   final String? acceptedTermsAndConditionsVersion;
 
   const TermsAndConditionsScreen({super.key, required this.validTermsAndConditions, this.acceptedTermsAndConditionsVersion});
 
   @override
-  State<TermsAndConditionsScreen> createState() => _TermsAndConditionsScreenState();
+  ConsumerState<TermsAndConditionsScreen> createState() => _TermsAndConditionsScreenState();
 }
 
-class _TermsAndConditionsScreenState extends State<TermsAndConditionsScreen> {
+class _TermsAndConditionsScreenState extends ConsumerState<TermsAndConditionsScreen> {
   bool isAccepted = false;
 
   void _setAccepted(bool val) {
@@ -110,7 +110,7 @@ class _TermsAndConditionsScreenState extends State<TermsAndConditionsScreen> {
             ),
             const SizedBox(height: 9),
             ElevatedButton(
-              onPressed: _onAcceptButtonPressed(context),
+              onPressed: _onAcceptButtonPressed(ref),
               child: const Text('Continue'),
             ),
           ],
@@ -119,13 +119,13 @@ class _TermsAndConditionsScreenState extends State<TermsAndConditionsScreen> {
     );
   }
 
-  Function()? _onAcceptButtonPressed(BuildContext context) {
+  Function()? _onAcceptButtonPressed(WidgetRef ref) {
     if (isAccepted) {
       return () {
         final tac = AcceptedTermsAndConditions(
           version: widget.validTermsAndConditions.version,
         );
-        context.read<TermsAndConditionAcceptance>().userAccepted(tac);
+        ref.read(termsAndConditionsAcceptedVersionNotifierProvider.notifier).userAccepted(tac);
       };
     }
     return null;

--- a/lib/state/network.dart
+++ b/lib/state/network.dart
@@ -1,6 +1,4 @@
-import 'package:concordium_wallet/state/config.dart';
 import 'package:concordium_wallet/services/wallet_proxy/service.dart';
-import 'package:flutter/foundation.dart';
 
 /// Name of a network.
 class NetworkName {
@@ -24,19 +22,4 @@ class Network {
   final WalletProxyConfig walletProxyConfig;
 
   const Network({required this.name, required this.walletProxyConfig});
-}
-
-/// State component acting as the source of truth for what network is currently active in the app.
-class ActiveNetwork extends ChangeNotifier {
-  /// Currently active network.
-  ///
-  /// The network is guaranteed to be one of the "enabled" networks (as defined in [Config.availableNetworks]).
-  Network active;
-
-  ActiveNetwork(this.active);
-
-  void setActive(Network n) {
-    active = n;
-    notifyListeners();
-  }
 }

--- a/lib/state/services.dart
+++ b/lib/state/services.dart
@@ -3,6 +3,8 @@ import 'package:concordium_wallet/services/shared_preferences/service.dart';
 import 'package:concordium_wallet/services/wallet_proxy/service.dart';
 import 'package:concordium_wallet/state/config.dart';
 import 'package:concordium_wallet/state/network.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Collection of all services of a network.
 class NetworkServices {
@@ -31,3 +33,22 @@ class ServiceRepository {
 
   const ServiceRepository({required this.networkServices, required this.sharedPreferences});
 }
+
+/// Provider for 'ServiceRepository'.
+///
+/// The implementation is a simple placeholder that just throws an error.
+/// It's expected to be overridden in 'ProviderScope' by the result of 'initServiceRepository'; see 'main.dart'.
+/// The reason for this setup is to avoid the provider from having to be async just because it's initialization is.
+/// Rather, we want to wait for the value to be available on app startup and then use the value without async.
+final serviceRepositoryProvider = Provider<ServiceRepository>((ref) {
+  throw UnimplementedError();
+});
+
+Future<ServiceRepository> initServiceRepository(Network n, HttpService httpService) async {
+  final prefs = await SharedPreferences.getInstance();
+  return ServiceRepository(
+    networkServices: {n: NetworkServices.forNetwork(n, httpService: httpService)},
+    sharedPreferences: SharedPreferencesService(prefs),
+  );
+}
+

--- a/lib/state/terms_and_conditions.g.dart
+++ b/lib/state/terms_and_conditions.g.dart
@@ -1,0 +1,64 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'terms_and_conditions.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$validTermsAndConditionsHash() =>
+    r'19c4f9af56b9fee03a153f4782b684194e14f918';
+
+/// See also [validTermsAndConditions].
+@ProviderFor(validTermsAndConditions)
+final validTermsAndConditionsProvider =
+    AutoDisposeFutureProvider<ValidTermsAndConditions?>.internal(
+  validTermsAndConditions,
+  name: r'validTermsAndConditionsProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$validTermsAndConditionsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef ValidTermsAndConditionsRef
+    = AutoDisposeFutureProviderRef<ValidTermsAndConditions?>;
+String _$activeNetworkNotifierHash() =>
+    r'9032bbbcf2f4123ea63b45337d22e1647fea5224';
+
+/// See also [ActiveNetworkNotifier].
+@ProviderFor(ActiveNetworkNotifier)
+final activeNetworkNotifierProvider =
+    AutoDisposeNotifierProvider<ActiveNetworkNotifier, Network?>.internal(
+  ActiveNetworkNotifier.new,
+  name: r'activeNetworkNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$activeNetworkNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ActiveNetworkNotifier = AutoDisposeNotifier<Network?>;
+String _$termsAndConditionsAcceptedVersionNotifierHash() =>
+    r'b02eefe609ca9515dcc4b25439fa05fb36684dc9';
+
+/// See also [TermsAndConditionsAcceptedVersionNotifier].
+@ProviderFor(TermsAndConditionsAcceptedVersionNotifier)
+final termsAndConditionsAcceptedVersionNotifierProvider =
+    AutoDisposeNotifierProvider<TermsAndConditionsAcceptedVersionNotifier,
+        AcceptedTermsAndConditions?>.internal(
+  TermsAndConditionsAcceptedVersionNotifier.new,
+  name: r'termsAndConditionsAcceptedVersionNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$termsAndConditionsAcceptedVersionNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$TermsAndConditionsAcceptedVersionNotifier
+    = AutoDisposeNotifier<AcceptedTermsAndConditions?>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.2.0"
+  analyzer_plugin:
+    dependency: transitive
+    description:
+      name: analyzer_plugin
+      sha256: "9661b30b13a685efaee9f02e5d01ed9f2b423bd889d28a304d02d704aee69161"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.3"
   args:
     dependency: transitive
     description:
@@ -121,6 +129,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  ci:
+    dependency: transitive
+    description:
+      name: ci
+      sha256: "145d095ce05cddac4d797a158bc4cf3b6016d1fe63d8c3d2fbd7212590adca13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      sha256: b8db3080e59b2503ca9e7922c3df2072cf13992354d5e944074ffa836fba43b7
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   clock:
     dependency: transitive
     description:
@@ -169,6 +193,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
+  custom_lint:
+    dependency: "direct dev"
+    description:
+      name: custom_lint
+      sha256: f9a828b696930cf8307f9a3617b2b65c9b370e484dc845d69100cadb77506778
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.6"
+  custom_lint_core:
+    dependency: transitive
+    description:
+      name: custom_lint_core
+      sha256: e20a67737adcf0cf2465e734dd624af535add11f9edd1f2d444909b5b0749650
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.6"
   dart_style:
     dependency: transitive
     description:
@@ -222,6 +262,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "305203d1578f6857675f9730568548b03900ce53afd319f4aa9d2fa943334dbe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.5"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -240,6 +288,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      sha256: c3fd9336eb55a38cc1bbd79ab17573113a8deccd0ecbbf926cca3c62803b5c2d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   frontend_server_client:
     dependency: transitive
     description:
@@ -368,14 +424,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
-  nested:
-    dependency: transitive
-    description:
-      name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
@@ -456,14 +504,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
-  provider:
-    dependency: "direct main"
-    description:
-      name: provider
-      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -480,6 +520,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "2e84315036e64c59affaff7443dea51247bc2fe704461a32f26a27986fb63d55"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.5"
+  riverpod_analyzer_utils:
+    dependency: transitive
+    description:
+      name: riverpod_analyzer_utils
+      sha256: "22a089135785f27e601075023f93c6622c43ef28c3ba1bef303cfbc314028e64"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.3"
+  riverpod_annotation:
+    dependency: "direct main"
+    description:
+      name: riverpod_annotation
+      sha256: "9330309e4400f40e39a2a1d1c340e775d0fd23451cf2dd2286e03c7896fd2bd5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  riverpod_generator:
+    dependency: "direct dev"
+    description:
+      name: riverpod_generator
+      sha256: "0a1c8eeb3dba2ce704eb1a4c3b8043716d52bedaaaa5b2725e0bde67ca38a46e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.5"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -581,6 +661,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -589,6 +677,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:
@@ -709,6 +805,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.8"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: b715b8d3858b6fa9f68f87d20d98830283628014750c2b09b6f516c1da4af2a7
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   vector_graphics:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,11 +37,12 @@ dependencies:
   cupertino_icons: ^1.0.2
   json_annotation: ^4.8.1
   build_runner: ^2.4.6
-  provider: ^6.0.5
   flutter_svg: ^2.0.7
   url_launcher: ^6.1.14
   shared_preferences: ^2.2.1
   http: ^1.1.0
+  flutter_riverpod: ^2.4.5
+  riverpod_annotation: ^2.3.0
 
 dev_dependencies:
   flutter_test:
@@ -54,6 +55,8 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
   json_serializable: ^6.7.1
+  riverpod_generator: ^2.3.5
+  custom_lint: ^0.5.6
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
This PR is just intended to illustrate what a Riverpod implementation might look like. It attempts to be faithful to the intended use of Riverpod, but it isn't intended to get merged. Rather, it serves to illustrate the problems that using Riverpod might inflict on our project:

- Providers can only be initialized lazily or using hacks. We want to initialize `SharedPreferences` (which is async) early on to avoid providers that aren't inherently async having to be async anyway just because they use this dependency. Or, as in the current case, the consuming provider is async, but the dependency being async makes the notion of the provider being "pending" less clearly defined. The official recommendation is to keep the dependency async and use `requireValue` to force unwrapping on runtime. To me this is an unacceptable loss of type safety; the consumer should not be required to know when the asynchronicity is "real" and when it isn't.
- The same problem occurs with "active network": We don't want to hardcode the default value into the provider so instead initialize it in `initState` of a stateful component. There are other options but none of them are what we want: To simply provide the value from some configuration that isn't necessarily a global singleton.
- Code navigation suffers from code generation splitting definitions across files: To find the usage of, say, a notifier class, you have to first find its usage in the generated code, then find the usage of the actual provider defined in there. While code generation is optional, it's highly encouraged. And it looks like nontrivial providers are hard to write without it. But even code generation is used, you might get very cryptic errors in the generated code when you don't get it exactly right.
- Subjectively, it seems hard to find a good way to organize the providers. They tend to get rather fine grained which makes it hard to get an overview, especially if you'd like to know what is initialized and when. It feels like this could work against building the right abstractions.
- Something that isn't clear in this code is that the life cycle providers ("auto disposable") by default is tied to that of consuming widgets. This is probably very powerful and what you want most of the time. But when it isn't I fear that this could turn into error prone memory management.

To be clear, this is not to say that Riverpod is a bad library. It just feels a bit too magic and has some limitations that I think makes it unsuitable for our project. You get some advantages in exchange for these things, but it isn't clear to me how valuable they are compared to Bloc which is much easier to understand.