### PR TITLE
Refactoring: Improve initialization and network structure

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,8 +30,10 @@ Future<Config> loadConfig(HttpService http) async {
 
 Future<ServiceRepository> bootstrap() async {
   const http = HttpService();
-  final config = await loadConfig(http);
-  final prefs = await SharedPreferences.getInstance();
+  final configFuture = loadConfig(http);
+  final prefsFuture = SharedPreferences.getInstance();
+  final config = await configFuture;
+  final prefs = await prefsFuture;
   return ServiceRepository(
     config: config,
     http: http,

--- a/lib/screens/home/screen.dart
+++ b/lib/screens/home/screen.dart
@@ -1,7 +1,6 @@
 import 'package:concordium_wallet/screens/terms_and_conditions/screen.dart';
 import 'package:concordium_wallet/services/wallet_proxy/service.dart';
 import 'package:concordium_wallet/state/network.dart';
-import 'package:concordium_wallet/state/services.dart';
 import 'package:concordium_wallet/state/terms_and_conditions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -30,10 +29,9 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   void _refresh(BuildContext context) {
-    final network = context.read<ActiveNetwork>().state;
-    final services = context.read<ServiceRepository>().networkServices[network.active]!;
+    final network = context.read<SelectedNetwork>().state;
     final tacAcceptance = context.read<TermsAndConditionAcceptance>();
-    _updateValidTac(services.walletProxy, tacAcceptance);
+    _updateValidTac(network.services.walletProxy, tacAcceptance);
   }
 
   @override

--- a/lib/services/wallet_proxy/service.dart
+++ b/lib/services/wallet_proxy/service.dart
@@ -35,14 +35,14 @@ class WalletProxyService {
   final WalletProxyConfig config;
 
   /// HTTP service used to send requests to the instance.
-  final HttpService httpService;
+  final HttpService http;
 
-  const WalletProxyService({required this.config, required this.httpService});
+  const WalletProxyService({required this.config, required this.http});
 
   /// Fetches the currently valid T&C.
   Future<TermsAndConditions> fetchTermsAndConditions() async {
     final url = config.urlOf(WalletProxyEndpoint.termsAndConditionsVersion);
-    final response = await httpService.get(url);
+    final response = await http.get(url);
     final jsonResponse = jsonDecode(response.body);
     return TermsAndConditions.fromJson(jsonResponse);
   }

--- a/lib/state/config.dart
+++ b/lib/state/config.dart
@@ -20,6 +20,8 @@ class Config {
   /// At some other point we'll introduce a notion of "enabled" networks,
   /// i.e. the list of networks to be included in the user's network selector.
   /// That list will be a subset of the available networks.
+  /// Furthermore, the "active" networks are are subset of the enabled networks where we have actual services initialized.
+  /// Lastly, the "selected" network is the active network that we're actually currently using in the app.
   /// The purpose of describing the concept here already is to allow other doc comments to reference it early.
   final Map<NetworkName, Network> availableNetworks;
 

--- a/lib/state/config.dart
+++ b/lib/state/config.dart
@@ -20,9 +20,9 @@ class Config {
   /// At some other point we'll introduce a notion of "enabled" networks,
   /// i.e. the list of networks to be included in the user's network selector.
   /// That list will be a subset of the available networks.
-  /// Furthermore, the "active" networks are are subset of the enabled networks where we have actual services initialized.
+  /// Furthermore, the set of "active" networks is a subset of the enabled networks where we have actual services initialized.
   /// Lastly, the "selected" network is the active network that we're actually currently using in the app.
-  /// The purpose of describing the concept here already is to allow other doc comments to reference it early.
+  /// The purpose of describing the concepts before they're fully implemented is to allow other doc comments to reference them already.
   final Map<NetworkName, Network> availableNetworks;
 
   const Config({required this.availableNetworks});

--- a/lib/state/network.dart
+++ b/lib/state/network.dart
@@ -1,5 +1,6 @@
 import 'package:concordium_wallet/state/config.dart';
 import 'package:concordium_wallet/services/wallet_proxy/service.dart';
+import 'package:concordium_wallet/state/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// Name of a network.
@@ -26,20 +27,20 @@ class Network {
   const Network({required this.name, required this.walletProxyConfig});
 }
 
-class ActiveNetworkState {
-  /// Currently active network.
+class SelectedNetworkState {
+  /// Services corresponding to the currently selected network (as defined in [Config.availableNetworks]).
   ///
-  /// The network is guaranteed to be one of the "enabled" networks (as defined in [Config.availableNetworks]).
-  Network active;
+  /// The network is guaranteed to be one of the entries in [ServiceRepository.activeNetworks].
+  final NetworkServices services;
 
-  ActiveNetworkState(this.active);
+  const SelectedNetworkState(this.services);
 }
 
-/// State component acting as the source of truth for what network is currently active in the app.
-class ActiveNetwork extends Cubit<ActiveNetworkState> {
-  ActiveNetwork(Network active) : super(ActiveNetworkState(active));
+/// State component acting as the source of truth for what network is currently selected in the app.
+class SelectedNetwork extends Cubit<SelectedNetworkState> {
+  SelectedNetwork(NetworkServices services) : super(SelectedNetworkState(services));
 
-  void setActive(Network n) {
-    emit(ActiveNetworkState(n));
+  void select(NetworkServices networkServices) {
+    emit(SelectedNetworkState(networkServices));
   }
 }


### PR DESCRIPTION
## Purpose

- Prepare for initialization to be asynchronous and for config to be fetched rather than hardcoded.
- Clarify the intended network management architecture and simplify the way you access services belonging to the currently selected network.

## Changes

Ensured that the types of functions/methods that we know/expect are going to become asynchronous are made so right away in order to avoid having to change the widget structure later on. Concretely, this includes `ServiceRepository.activateNetwork` and config loading.

Changed "loading shared preferences" into more generic "bootstrap" procedure that is also going to load configuration and whatever other services are going to be added (like DB client).

Changed `ActiveNetwork` to `SelectedNetwork` as, during transition, a network can be active without being selected for a brief time. Its state is now the actual services to access instead of just the lookup key. This makes it simpler and less error prone to access them. `NetworkServices` now has a reference to `Network` so this leads to no loss of information. The only difference is that `NetworkServices` is initialized async, meaning that the value isn't immediately available. This is probably a good thing as it prevents you from attempting to interact with a network before it's ready.