### PR TITLE
Split root widget to fix wrong usage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -83,7 +83,7 @@ class _WithServiceRepository extends StatefulWidget {
 }
 
 class _WithServiceRepositoryState extends State<_WithServiceRepository> {
-  Future<ServiceRepository>? _future;
+  late final Future<ServiceRepository> _future;
 
   @override
   void initState() {
@@ -123,7 +123,7 @@ class _WithSelectedNetwork extends StatefulWidget {
 }
 
 class _WithSelectedNetworkState extends State<_WithSelectedNetwork> {
-  Future<NetworkServices>? _future;
+  late final Future<NetworkServices> _future;
 
   @override
   void initState() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,27 +76,27 @@ class App extends StatelessWidget {
 class _WithServiceRepository extends StatefulWidget {
   final Widget child;
 
-  const _WithServiceRepository({super.key, required this.child});
+  const _WithServiceRepository({required this.child});
 
   @override
   State<_WithServiceRepository> createState() => _WithServiceRepositoryState();
 }
 
 class _WithServiceRepositoryState extends State<_WithServiceRepository> {
-  late final Future<ServiceRepository> _future;
+  late final Future<ServiceRepository> _bootstrapping;
 
   @override
   void initState() {
     super.initState();
     setState(() {
-      _future = bootstrap();
+      _bootstrapping = bootstrap();
     });
   }
 
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<ServiceRepository>(
-      future: _future,
+      future: _bootstrapping,
       builder: (_, snapshot) {
         final services = snapshot.data;
         if (services == null) {
@@ -116,28 +116,28 @@ class _WithSelectedNetwork extends StatefulWidget {
   final NetworkName initialNetwork;
   final Widget child;
 
-  const _WithSelectedNetwork({super.key, required this.initialNetwork, required this.child});
+  const _WithSelectedNetwork({required this.initialNetwork, required this.child});
 
   @override
   State<_WithSelectedNetwork> createState() => _WithSelectedNetworkState();
 }
 
 class _WithSelectedNetworkState extends State<_WithSelectedNetwork> {
-  late final Future<NetworkServices> _future;
+  late final Future<NetworkServices> _activating;
 
   @override
   void initState() {
     super.initState();
     final services = context.read<ServiceRepository>();
     setState(() {
-      _future = services.activateNetwork(initialNetwork);
+      _activating = services.activateNetwork(initialNetwork);
     });
   }
 
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      future: _future,
+      future: _activating,
       builder: (_, snapshot) {
         final networkServices = snapshot.data;
         if (networkServices == null) {


### PR DESCRIPTION
The current widget `App` uses two nested `FutureBuilder`s in a wrong way: The provided future should not be constructed inside the build method. As the [documentation](https://api.flutter.dev/flutter/widgets/FutureBuilder-class.html#managing-the-future) puts it:

> The future must have been obtained earlier, e.g. during State.initState, State.didUpdateWidget, or State.didChangeDependencies. It must not be created during the State.build or StatelessWidget.build method call when constructing the FutureBuilder. If the future is created at the same time as the FutureBuilder, then every time the FutureBuilder's parent is rebuilt, the asynchronous task will be restarted.

This behavior has been observed during development as flickering and crashing due to duplicate network activation.

With this change the two `FutureBuilder`s now live in their own separate stateful widgets where the futures are constructed by their respective `initState` methods.

This change has the furtunate side effect of making the original widget much simpler and easier to understand.