### PR TITLE
Rename AcceptedTermsAndConditions types

### DIFF
--- a/lib/entities/accepted_terms_and_conditions.dart
+++ b/lib/entities/accepted_terms_and_conditions.dart
@@ -2,9 +2,9 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 part 'accepted_terms_and_conditions.g.dart';
 
-/// Version of the Terms & Conditions accepted by the user.
+/// Version of the Terms & Conditions accepted by the user and time of acceptance.
 @HiveType(typeId: 1)
-class AcceptedTermsAndConditions {
+class AcceptedTermsAndConditionsEntity {
   static const table = "accepted_terms_and_conditions";
 
   @HiveField(0)
@@ -12,5 +12,5 @@ class AcceptedTermsAndConditions {
   @HiveField(1)
   final DateTime acceptedAt;
 
-  AcceptedTermsAndConditions({required this.version, required this.acceptedAt});
+  const AcceptedTermsAndConditionsEntity({required this.version, required this.acceptedAt});
 }

--- a/lib/entities/accepted_terms_and_conditions.g.dart
+++ b/lib/entities/accepted_terms_and_conditions.g.dart
@@ -6,29 +6,29 @@ part of 'accepted_terms_and_conditions.dart';
 // TypeAdapterGenerator
 // **************************************************************************
 
-class AcceptedTermsAndConditionsAdapter extends TypeAdapter<AcceptedTermsAndConditions> {
+class AcceptedTermsAndConditionsEntityAdapter extends TypeAdapter<AcceptedTermsAndConditionsEntity> {
   @override
   final int typeId = 1;
 
   @override
-  AcceptedTermsAndConditions read(BinaryReader reader) {
+  AcceptedTermsAndConditionsEntity read(BinaryReader reader) {
     final numOfFields = reader.readByte();
     final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
-    return AcceptedTermsAndConditions(
-      version: fields[1] as String,
-      acceptedAt: fields[2] as DateTime,
+    return AcceptedTermsAndConditionsEntity(
+      version: fields[0] as String,
+      acceptedAt: fields[1] as DateTime,
     );
   }
 
   @override
-  void write(BinaryWriter writer, AcceptedTermsAndConditions obj) {
+  void write(BinaryWriter writer, AcceptedTermsAndConditionsEntity obj) {
     writer
       ..writeByte(2)
-      ..writeByte(1)
+      ..writeByte(0)
       ..write(obj.version)
-      ..writeByte(2)
+      ..writeByte(1)
       ..write(obj.acceptedAt);
   }
 
@@ -37,5 +37,5 @@ class AcceptedTermsAndConditionsAdapter extends TypeAdapter<AcceptedTermsAndCond
 
   @override
   bool operator ==(Object other) =>
-      identical(this, other) || other is AcceptedTermsAndConditionsAdapter && runtimeType == other.runtimeType && typeId == other.typeId;
+      identical(this, other) || other is AcceptedTermsAndConditionsEntityAdapter && runtimeType == other.runtimeType && typeId == other.typeId;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -159,7 +159,7 @@ class _WithTermsAndConditionAcceptance extends StatefulWidget {
 }
 
 class _WithTermsAndConditionAcceptanceState extends State<_WithTermsAndConditionAcceptance> {
-  late final Future<FutureValue<AcceptedTermsAndConditionsState?>> _lastAccepted;
+  late final Future<FutureValue<AcceptedTermsAndConditions?>> _lastAccepted;
   late final TermsAndConditionsRepository _repository;
 
   @override

--- a/lib/providers/storage.dart
+++ b/lib/providers/storage.dart
@@ -3,7 +3,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 /// Service for interacting with [Hive].
 class StorageProvider {
-  final LazyBox<AcceptedTermsAndConditions> _acceptedTermsAndConditionBox;
+  final LazyBox<AcceptedTermsAndConditionsEntity> _acceptedTermsAndConditionBox;
 
   const StorageProvider._(this._acceptedTermsAndConditionBox);
 
@@ -12,22 +12,22 @@ class StorageProvider {
     _registerAdapters();
     await _openBoxes();
 
-    return StorageProvider._(Hive.lazyBox<AcceptedTermsAndConditions>(AcceptedTermsAndConditions.table));
+    return StorageProvider._(Hive.lazyBox<AcceptedTermsAndConditionsEntity>(AcceptedTermsAndConditionsEntity.table));
   }
 
   /// Register all adapters needed for typed boxes.
   static void _registerAdapters() {
-    Hive.registerAdapter(AcceptedTermsAndConditionsAdapter());
+    Hive.registerAdapter(AcceptedTermsAndConditionsEntityAdapter());
     Hive.registerAdapter(PreciseDateTimeAdapter(), override: true, internal: true);
   }
 
   /// Opens all boxes asynchronously.
   static Future<void> _openBoxes() async {
-    final atcFuture = Hive.openLazyBox<AcceptedTermsAndConditions>(AcceptedTermsAndConditions.table);
+    final atcFuture = Hive.openLazyBox<AcceptedTermsAndConditionsEntity>(AcceptedTermsAndConditionsEntity.table);
     await Future.wait([atcFuture]);
   }
 
-  LazyBox<AcceptedTermsAndConditions> get acceptedTermsAndConditionBox => _acceptedTermsAndConditionBox;
+  LazyBox<AcceptedTermsAndConditionsEntity> get acceptedTermsAndConditionBox => _acceptedTermsAndConditionBox;
 }
 
 /// A bit modified DateTimeWithTimezoneAdapter (https://github.com/isar/hive/blob/470473ffc1ba39f6c90f31ababe0ee63b76b69fe/hive/lib/src/adapters/date_time_adapter.dart#L25)

--- a/lib/repositories/terms_and_conditions_repository.dart
+++ b/lib/repositories/terms_and_conditions_repository.dart
@@ -10,13 +10,13 @@ class TermsAndConditionsRepository {
   const TermsAndConditionsRepository({required StorageProvider storageProvider}) : _storageProvider = storageProvider;
 
   /// Reads the currently accepted T&C version.
-  Future<AcceptedTermsAndConditionsState?> getAcceptedTermsAndConditions() async {
+  Future<AcceptedTermsAndConditions?> getAcceptedTermsAndConditions() async {
     var model = await _storageProvider.acceptedTermsAndConditionBox.get(key);
     return _toState(model);
   }
 
   /// Writes the currently accepted T&C version.
-  Future<void> writeAcceptedTermsAndConditions(AcceptedTermsAndConditionsState acceptedTermsAndConditions) {
+  Future<void> writeAcceptedTermsAndConditions(AcceptedTermsAndConditions acceptedTermsAndConditions) {
     return _storageProvider.acceptedTermsAndConditionBox.put(key, _fromState(acceptedTermsAndConditions));
   }
 
@@ -25,14 +25,14 @@ class TermsAndConditionsRepository {
     return _storageProvider.acceptedTermsAndConditionBox.delete(key);
   }
 
-  AcceptedTermsAndConditions _fromState(AcceptedTermsAndConditionsState state) {
-    return AcceptedTermsAndConditions(version: state.version, acceptedAt: state.acceptedAt);
+  AcceptedTermsAndConditionsEntity _fromState(AcceptedTermsAndConditions state) {
+    return AcceptedTermsAndConditionsEntity(version: state.version, acceptedAt: state.acceptedAt);
   }
 
-  AcceptedTermsAndConditionsState? _toState(AcceptedTermsAndConditions? model) {
+  AcceptedTermsAndConditions? _toState(AcceptedTermsAndConditionsEntity? model) {
     if (model == null) {
       return null;
     }
-    return AcceptedTermsAndConditionsState(version: model.version, acceptedAt: model.acceptedAt);
+    return AcceptedTermsAndConditions(version: model.version, acceptedAt: model.acceptedAt);
   }
 }

--- a/lib/screens/home/screen.dart
+++ b/lib/screens/home/screen.dart
@@ -92,7 +92,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 const SizedBox(height: 8),
                 ElevatedButton(
                   onPressed: () {
-                    final tac = AcceptedTermsAndConditionsState.acceptNow('1.2.3');
+                    final tac = AcceptedTermsAndConditions.acceptedNow('1.2.3');
                     context.read<TermsAndConditionAcceptance>().userAccepted(tac);
                   },
                   child: const Text('Set accepted T&C version to 1.2.3'),

--- a/lib/screens/terms_and_conditions/screen.dart
+++ b/lib/screens/terms_and_conditions/screen.dart
@@ -124,7 +124,7 @@ class _TermsAndConditionsScreenState extends State<TermsAndConditionsScreen> {
   Function()? _onAcceptButtonPressed(BuildContext context) {
     if (isAccepted) {
       return () {
-        final tac = AcceptedTermsAndConditionsState.acceptNow(widget.validTermsAndConditions.version);
+        final tac = AcceptedTermsAndConditions.acceptedNow(widget.validTermsAndConditions.version);
         context.read<TermsAndConditionAcceptance>().userAccepted(tac);
       };
     }

--- a/lib/state/terms_and_conditions.dart
+++ b/lib/state/terms_and_conditions.dart
@@ -2,16 +2,18 @@ import 'package:concordium_wallet/repositories/terms_and_conditions_repository.d
 import 'package:concordium_wallet/services/wallet_proxy/model.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-/// Version of the Terms & Conditions accepted by the user.
-class AcceptedTermsAndConditionsState {
+/// Version of the Terms & Conditions accepted by the user and time of acceptance.
+class AcceptedTermsAndConditions {
   /// Accepted version.
   final String version;
+
+  /// Time of acceptance.
   final DateTime acceptedAt;
 
-  const AcceptedTermsAndConditionsState({required this.version, required this.acceptedAt});
+  const AcceptedTermsAndConditions({required this.version, required this.acceptedAt});
 
-  factory AcceptedTermsAndConditionsState.acceptNow(String acceptedVersion) {
-    return AcceptedTermsAndConditionsState(version: acceptedVersion, acceptedAt: DateTime.now());
+  factory AcceptedTermsAndConditions.acceptedNow(String acceptedVersion) {
+    return AcceptedTermsAndConditions(version: acceptedVersion, acceptedAt: DateTime.now());
   }
 
   /// Whether the accepted version is valid with respect to the provided valid version.
@@ -43,7 +45,7 @@ class TermsAndConditionsAcceptanceState {
   /// Currently accepted T&C.
   ///
   /// The accepted version persisted.
-  final AcceptedTermsAndConditionsState? accepted;
+  final AcceptedTermsAndConditions? accepted;
 
   /// Currently valid T&C.
   final ValidTermsAndConditions? valid;
@@ -56,7 +58,7 @@ class TermsAndConditionAcceptance extends Cubit<TermsAndConditionsAcceptanceStat
   /// Service used to persist the accepted T&C version.
   final TermsAndConditionsRepository _termsAndConditionRepo;
 
-  TermsAndConditionAcceptance(this._termsAndConditionRepo, AcceptedTermsAndConditionsState? acceptedVersion)
+  TermsAndConditionAcceptance(this._termsAndConditionRepo, AcceptedTermsAndConditions? acceptedVersion)
       : super(const TermsAndConditionsAcceptanceState(accepted: null, valid: null)) {
     if (acceptedVersion != null) {
       userAccepted(acceptedVersion);
@@ -66,7 +68,7 @@ class TermsAndConditionAcceptance extends Cubit<TermsAndConditionsAcceptanceStat
   /// Update the currently accepted T&C and persist the new value.
   ///
   /// Use [resetAccepted] to revoke acceptance.
-  void userAccepted(AcceptedTermsAndConditionsState tac) {
+  void userAccepted(AcceptedTermsAndConditions tac) {
     emit(TermsAndConditionsAcceptanceState(accepted: tac, valid: state.valid));
   }
 
@@ -112,7 +114,7 @@ class TermsAndConditionAcceptance extends Cubit<TermsAndConditionsAcceptanceStat
     }
   }
 
-  Future<void> _persistAcceptedVersion(AcceptedTermsAndConditionsState? nextAcceptedVersion) {
+  Future<void> _persistAcceptedVersion(AcceptedTermsAndConditions? nextAcceptedVersion) {
     if (nextAcceptedVersion == null) {
       return _termsAndConditionRepo.deleteTermsAndConditionsAcceptedVersion();
     }

--- a/test/repositories/terms_and_conditions_repository_test.dart
+++ b/test/repositories/terms_and_conditions_repository_test.dart
@@ -26,12 +26,12 @@ void main() {
 
   tearDownAll(() => Hive.deleteFromDisk());
 
-  tearDown(() => Hive.lazyBox<AcceptedTermsAndConditions>(AcceptedTermsAndConditions.table).clear());
+  tearDown(() => Hive.lazyBox<AcceptedTermsAndConditionsEntity>(AcceptedTermsAndConditionsEntity.table).clear());
 
   test('When add accepted terms and condition to storage, then saved', () async {
     // Arrange
     const expectedVersion = "0.0.42";
-    final accepted = AcceptedTermsAndConditionsState.acceptNow(expectedVersion);
+    final accepted = AcceptedTermsAndConditions.acceptedNow(expectedVersion);
 
     // Act
     await repository.writeAcceptedTermsAndConditions(accepted);
@@ -45,9 +45,10 @@ void main() {
   test("When delete accepted terms and condition from storage, then empty", () async {
     // Arrange
     const expectedVersion = "0.0.42";
-    final accepted = AcceptedTermsAndConditionsState.acceptNow(expectedVersion);
+    final accepted = AcceptedTermsAndConditions.acceptedNow(expectedVersion);
     await repository.writeAcceptedTermsAndConditions(accepted);
-    expect(await Hive.lazyBox<AcceptedTermsAndConditions>(AcceptedTermsAndConditions.table).get(TermsAndConditionsRepository.key), isNotNull);
+    expect(await Hive.lazyBox<AcceptedTermsAndConditionsEntity>(AcceptedTermsAndConditionsEntity.table).get(TermsAndConditionsRepository.key),
+        isNotNull);
 
     // Act
     await repository.deleteTermsAndConditionsAcceptedVersion();
@@ -61,10 +62,11 @@ void main() {
     // Arrange
     const oldVersion = "0.0.42";
     const newVersion = "0.0.84";
-    final oldAccepted = AcceptedTermsAndConditionsState.acceptNow(oldVersion);
-    final newAccepted = AcceptedTermsAndConditionsState.acceptNow(newVersion);
+    final oldAccepted = AcceptedTermsAndConditions.acceptedNow(oldVersion);
+    final newAccepted = AcceptedTermsAndConditions.acceptedNow(newVersion);
     await repository.writeAcceptedTermsAndConditions(oldAccepted);
-    expect(await Hive.lazyBox<AcceptedTermsAndConditions>(AcceptedTermsAndConditions.table).get(TermsAndConditionsRepository.key), isNotNull);
+    expect(await Hive.lazyBox<AcceptedTermsAndConditionsEntity>(AcceptedTermsAndConditionsEntity.table).get(TermsAndConditionsRepository.key),
+        isNotNull);
 
     // Act
     await repository.writeAcceptedTermsAndConditions(newAccepted);

--- a/test/terms_and_conditions_test.dart
+++ b/test/terms_and_conditions_test.dart
@@ -25,7 +25,7 @@ void main() {
     const String acceptedVersion = "1.0.0";
 
     setUpAll(() {
-      registerFallbackValue(AcceptedTermsAndConditionsState.acceptNow(validVersion));
+      registerFallbackValue(AcceptedTermsAndConditions.acceptedNow(validVersion));
     });
 
     setUp(() {
@@ -33,8 +33,7 @@ void main() {
 
       final terms = TermsAndConditions(Uri.parse("localhost"), validVersion);
       state = TermsAndConditionsAcceptanceState(
-          accepted: AcceptedTermsAndConditionsState.acceptNow(acceptedVersion),
-          valid: ValidTermsAndConditions.refreshedNow(termsAndConditions: terms));
+          accepted: AcceptedTermsAndConditions.acceptedNow(acceptedVersion), valid: ValidTermsAndConditions.refreshedNow(termsAndConditions: terms));
 
       // Build the terms and condition screen we wish to test
       final rawTacScreen = TermsAndConditionsScreen(validTermsAndConditions: terms, urlLauncher: MockUrlLauncher());


### PR DESCRIPTION
I think it's misleading to name the `AcceptedTermsAndConditionsState` "state" as it's really just a value that can be passed around, not necessarily in the context of state. It was renamed in a previous PR to give the new Hive entity its name instead. I think it's important to not refer to entity objects directly from the widgets, and therefore useful to explicitly suffix entity types with `Entity` to make it clear if it happens.

As such, the changes in this PR is just the renamings

- `AcceptedTermsAndConditionsState` -> `AcceptedTermsAndConditions`
- `AcceptedTermsAndConditions` -> `AcceptedTermsAndConditionsEntity`

Also `acceptNow` was renamed to `acceptedNow` to avoid indicating that it has a side effect.